### PR TITLE
DM-28135: Improve the schema and add required env var SITE_ID.

### DIFF
--- a/src/exposurelog/app.py
+++ b/src/exposurelog/app.py
@@ -14,6 +14,7 @@ from safir.metadata import setup_metadata
 from safir.middleware import bind_logger
 
 from exposurelog.config import Configuration
+from exposurelog.create_messages_table import SITE_ID_LEN
 from exposurelog.log_message_database import LogMessageDatabase
 from exposurelog.schemas.app_schema import app_schema
 
@@ -28,6 +29,13 @@ def create_app(**configs: typing.Any) -> web.Application:
         log_level=config.log_level,
         name=config.logger_name,
     )
+
+    if not config.site_id:
+        raise ValueError("Must specify SITE_ID")
+    if len(config.site_id) > SITE_ID_LEN:
+        raise ValueError(
+            f"SITE_ID={config.site_id!r} too long; max length={SITE_ID_LEN}"
+        )
 
     encoded_db_password = urllib.parse.quote_plus(
         config.exposurelog_db_password

--- a/src/exposurelog/config.py
+++ b/src/exposurelog/config.py
@@ -25,21 +25,33 @@ class Configuration:
     """
 
     exposurelog_db_user: str = os.getenv("EXPOSURELOG_DB_USER", "exposurelog")
-    """Exposurelog database user name."""
+    """Exposure log database user name."""
 
     exposurelog_db_password: str = os.getenv("EXPOSURELOG_DB_PASSWORD", "")
-    """Exposurelog database password."""
+    """Exposure log database password."""
 
     exposurelog_db_host: str = os.getenv("EXPOSURELOG_DB_HOST", "localhost")
-    """Exposurelog database server host."""
+    """Exposure log database server host."""
 
     exposurelog_db_port: str = os.getenv("EXPOSURELOG_DB_PORT", "5432")
-    """Exposurelog database server port."""
+    """Exposure log database server port."""
 
     exposurelog_db_database: str = os.getenv(
         "EXPOSURELOG_DB_DATABASE", "exposurelog"
     )
-    """Exposurelog database name."""
+    """Exposure log database name."""
+
+    site_id: str = os.getenv("SITE_ID", "")
+    """Site ID (required).
+
+    Requirements:
+
+    * It must be specified and not blank.
+    * It must be different for each exposure log deployment
+      (and thus each instance of the exposure log database)
+      in order for messages to be synchronized between databases.
+    * Its length must be <= exposurelog.create_messages_table.SITE_ID_LEN.
+    """
 
     name: str = os.getenv("SAFIR_NAME", "exposurelog")
     """The application's name, which doubles as the root HTTP endpoint path.

--- a/src/exposurelog/create_messages_table.py
+++ b/src/exposurelog/create_messages_table.py
@@ -1,8 +1,11 @@
-__all__ = ["create_messages_table"]
+__all__ = ["SITE_ID_LEN", "create_messages_table"]
 
 import typing
 
 import sqlalchemy as sa
+
+# Length of the site_id field.
+SITE_ID_LEN = 16
 
 
 def create_messages_table(
@@ -22,7 +25,8 @@ def create_messages_table(
     table = sa.Table(
         "messages",
         sa.MetaData(),
-        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("id", sa.BigInteger(), autoincrement=True, primary_key=True),
+        sa.Column("site_id", sa.String(length=SITE_ID_LEN), primary_key=True),
         sa.Column("obs_id", sa.String(), nullable=False),
         sa.Column("instrument", sa.String(), nullable=False),
         sa.Column("day_obs", sa.Integer(), nullable=False),
@@ -39,6 +43,11 @@ def create_messages_table(
         sa.Column("date_added", sa.DateTime(), nullable=False),
         sa.Column("date_is_valid_changed", sa.DateTime(), nullable=True),
         sa.Column("parent_id", sa.BigInteger(), nullable=True),
+        sa.Column("parent_site_id", sa.String(length=SITE_ID_LEN)),
+        sa.ForeignKeyConstraint(
+            ["parent_id", "parent_site_id"],
+            ["messages.id", "messages.site_id"],
+        ),
     )
 
     for name in (

--- a/src/exposurelog/resolvers/add_message.py
+++ b/src/exposurelog/resolvers/add_message.py
@@ -50,6 +50,7 @@ async def add_message(
     registries = app["exposurelog/registries"]
 
     data_dict = kwargs.copy()
+    data_dict["site_id"] = app["safir/config"].site_id
     data_dict["is_valid"] = True
     curr_tai = astropy.time.Time.now()
     data_dict["date_added"] = curr_tai.tai.iso

--- a/src/exposurelog/resolvers/delete_messages.py
+++ b/src/exposurelog/resolvers/delete_messages.py
@@ -35,13 +35,19 @@ async def delete_messages(
 
     # Validate the user data and handle defaults
     message_ids = kwargs["ids"]
+    site_id = kwargs["site_id"]
     current_tai = astropy.time.Time.now().tai.iso
 
     # Delete the messages
     async with exposurelog_db.engine.acquire() as connection:
         result_proxy = await connection.execute(
             exposurelog_db.table.update()
-            .where(exposurelog_db.table.c.id.in_(message_ids))
+            .where(
+                sa.sql.and_(
+                    exposurelog_db.table.c.id.in_(message_ids),
+                    exposurelog_db.table.c.site_id == site_id,
+                )
+            )
             .values(is_valid=False, date_is_valid_changed=current_tai)
             .returning(sa.literal_column("*"))
         )

--- a/src/exposurelog/resolvers/find_messages.py
+++ b/src/exposurelog/resolvers/find_messages.py
@@ -49,6 +49,7 @@ async def find_messages(
                 else:
                     conditions.append(column == None)  # noqa
             elif key in (
+                "site_ids",
                 "instruments",
                 "user_ids",
                 "user_agents",

--- a/src/exposurelog/schemas/delete_messages_field.py
+++ b/src/exposurelog/schemas/delete_messages_field.py
@@ -12,7 +12,11 @@ delete_messages_field = graphql.GraphQLField(
     args=dict(
         ids=graphql.GraphQLArgument(
             graphql.GraphQLList(graphql.GraphQLInt),
-            description="Message IDs.",
+            description="IDs of messages to delete.",
+        ),
+        site_id=graphql.GraphQLArgument(
+            graphql.GraphQLNonNull(graphql.GraphQLString),
+            description="Site ID of messages to delete.",
         ),
     ),
     resolve=delete_messages,

--- a/src/exposurelog/schemas/edit_message_field.py
+++ b/src/exposurelog/schemas/edit_message_field.py
@@ -14,6 +14,10 @@ edit_message_field = graphql.GraphQLField(
             graphql.GraphQLNonNull(graphql.GraphQLInt),
             description="ID of message to edit.",
         ),
+        site_id=graphql.GraphQLArgument(
+            graphql.GraphQLNonNull(graphql.GraphQLString),
+            description="Site ID of messages to edit.",
+        ),
         message_text=graphql.GraphQLArgument(
             graphql.GraphQLString,
             description="Message text",

--- a/src/exposurelog/schemas/find_messages_field.py
+++ b/src/exposurelog/schemas/find_messages_field.py
@@ -18,6 +18,10 @@ find_messages_field = graphql.GraphQLField(
             graphql.GraphQLInt,
             description="Maximum message ID, exclusive.",
         ),
+        site_ids=graphql.GraphQLArgument(
+            graphql.GraphQLList(graphql.GraphQLString),
+            description="Site IDs.",
+        ),
         obs_id=graphql.GraphQLArgument(
             graphql.GraphQLString,
             description="Observation ID (a string) contains...",

--- a/src/exposurelog/schemas/message_type.py
+++ b/src/exposurelog/schemas/message_type.py
@@ -26,6 +26,10 @@ MessageType = graphql.GraphQLObjectType(
             graphql.GraphQLNonNull(graphql.GraphQLInt),
             description="Message ID.",
         ),
+        site_id=graphql.GraphQLField(
+            graphql.GraphQLNonNull(graphql.GraphQLString),
+            description="Site ID.",
+        ),
         obs_id=graphql.GraphQLField(
             graphql.GraphQLNonNull(graphql.GraphQLString),
             description="Observation ID (a string).",
@@ -77,6 +81,10 @@ MessageType = graphql.GraphQLObjectType(
         parent_id=graphql.GraphQLField(
             graphql.GraphQLInt,
             description="ID of parent message; None if no parent.",
+        ),
+        parent_site_id=graphql.GraphQLField(
+            graphql.GraphQLString,
+            description="Site ID.",
         ),
     ),
 )

--- a/src/exposurelog/testutils.py
+++ b/src/exposurelog/testutils.py
@@ -28,6 +28,8 @@ if typing.TYPE_CHECKING:
 MIN_DATE_RANDOM_MESSAGE = "2021-01-01"
 MAX_DATE_RANDOM_MESSAGE = "2022-12-31"
 
+TEST_SITE_ID = "test"
+
 random = np.random.RandomState(47)
 
 # Type annotation aliases
@@ -187,8 +189,9 @@ def random_str(nchar: int) -> str:
 def random_message() -> MessageDictT:
     """Make one random message, as a dict of field: value.
 
-    All messages will have ``id=None``, ``is_valid=True``,
-    ``date_is_valid_changed=None`` and and ``parent_id=None``.
+    All messages will have ``id=None``, ``site_id=TEST_SITE_ID``,
+    ``is_valid=True``, ``date_is_valid_changed=None``,
+    ``parent_id=None``, and ``parent_site_id=None``.
 
     Fields are in the same order as MessageType and the database schema,
     to make it easier to visually compare these messages to messages in
@@ -206,6 +209,7 @@ def random_message() -> MessageDictT:
       of earlier messages, as follows:
 
       * Set edited_message["parent_id"] = parent_message["id"]
+      * Set edited_message["parent_site_id"] = parent_message["site_id"]
       * Set parent_message["is_valid"] = False
       * Set parent_message["date_is_valid_changed"] =
         edited_message["date_added"]
@@ -214,6 +218,7 @@ def random_message() -> MessageDictT:
 
     message = dict(
         id=None,
+        site_id=TEST_SITE_ID,
         obs_id=random_str(nchar=18),
         instrument=random_str(nchar=16),
         day_obs=int(random_yyyymmdd),
@@ -226,6 +231,7 @@ def random_message() -> MessageDictT:
         date_added=random_date(),
         date_is_valid_changed=None,
         parent_id=None,
+        parent_site_id=None,
     )
 
     # Check that we have set all fields (not necessarily in order).
@@ -278,6 +284,7 @@ def random_messages(
                 parent_message_id_set.add(parent_message["id"])
                 break
         message["parent_id"] = parent_message["id"]
+        message["parent_site_id"] = parent_message["site_id"]
         parent_message["is_valid"] = False
         parent_message["date_is_valid_changed"] = message["date_added"]
     return message_list

--- a/tests/test_add_message.py
+++ b/tests/test_add_message.py
@@ -9,6 +9,7 @@ import testing.postgresql
 
 from exposurelog.app import create_app
 from exposurelog.testutils import (
+    TEST_SITE_ID,
     ArgDictT,
     MessageDictT,
     Requestor,
@@ -57,7 +58,9 @@ async def test_add_message(aiohttp_client: TestClient) -> None:
         create_test_database(postgresql, num_messages=0)
 
         db_config = db_config_from_dsn(postgresql.dsn())
-        app = create_app(**db_config, butler_uri_1=repo_path)
+        app = create_app(
+            **db_config, butler_uri_1=repo_path, site_id=TEST_SITE_ID
+        )
         name = app["safir/config"].name
 
         client = await aiohttp_client(app)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ import requests
 import testing.postgresql
 
 from exposurelog.format_http_request import format_http_request
-from exposurelog.testutils import db_config_from_dsn
+from exposurelog.testutils import TEST_SITE_ID, db_config_from_dsn
 
 # Time limit for `exposurelog create-table` (sec).
 CREATE_TIMEOUT = 5
@@ -30,6 +30,7 @@ async def test_cli() -> None:
     """Test exposurelog create-table and run command-line commands."""
     repo_path = pathlib.Path(__file__).parent / "data" / "hsc_raw"
     os.environ["BUTLER_URI_1"] = str(repo_path)
+    os.environ["SITE_ID"] = TEST_SITE_ID
 
     exe_path = shutil.which("exposurelog")
     assert (

--- a/tests/test_find_messages.py
+++ b/tests/test_find_messages.py
@@ -10,6 +10,7 @@ import testing.postgresql
 from exposurelog.app import create_app
 from exposurelog.schemas.message_type import MessageType
 from exposurelog.testutils import (
+    TEST_SITE_ID,
     MessageDictT,
     Requestor,
     assert_good_response,
@@ -181,7 +182,9 @@ async def test_find_messages(aiohttp_client: TestClient) -> None:
         )
 
         db_config = db_config_from_dsn(postgresql.dsn())
-        app = create_app(**db_config, butler_uri_1=repo_path)
+        app = create_app(
+            **db_config, butler_uri_1=repo_path, site_id=TEST_SITE_ID
+        )
         name = app["safir/config"].name
 
         client = await aiohttp_client(app)


### PR DESCRIPTION
Update the schema to make records easier to synchronize,
by making the primary key unique across all copies of the database.
Schema changes:

* Add fields site_id and parent_site_id.
* Make the primary key a composite of id and site_id.
* Make parent_id and parent_site_id foreign keys. This prevents deleting a message if there is an edited version of the message. Not that we plan to delete any messages, but it is best practice.

Thanks to Andy Salnikov for suggesting this improved schema.