### PR TITLE
DM-33642: Remove BUTLER_WRITEABLE_HACK

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
           key: tox-${{ hashFiles('requirements/*.txt') }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Run tox
-        run: tox -e lint,py,coverage-report,typing  # run tox using Python in path
+        run: tox -e lint,py,coverage-report  # run tox using Python in path
 
   build:
     runs-on: ubuntu-latest

--- a/src/exposurelog/shared_state.py
+++ b/src/exposurelog/shared_state.py
@@ -110,17 +110,6 @@ class SharedState:
                 f"SITE_ID={site_id!r} too long; max length={SITE_ID_LEN}"
             )
 
-        # TODO DM-33642: get rid of BUTLER_WRITEABLE_HACK support
-        # and construct Butlers with writeable=False, when safe to do so.
-        butler_writeable_hack_str = get_env("BUTLER_WRITEABLE_HACK", "")
-        if butler_writeable_hack_str not in ("true", ""):
-            raise ValueError(
-                f"BUTLER_WRITEABLE_HACK={butler_writeable_hack_str} "
-                "must be 'true' or ''"
-            )
-        butler_writeable_hack = butler_writeable_hack_str == "true"
-        del butler_writeable_hack_str
-
         self.registries: list[lsst.daf.butler.Registry] = []
         for i in range(self.num_registries):
             uri_attr_name = f"butler_uri_{i + 1}"
@@ -129,9 +118,7 @@ class SharedState:
             butler_uri = get_env(uri_attr_name.upper(), default=default)
             setattr(self, uri_attr_name, butler_uri)
             if butler_uri != "":
-                butler = lsst.daf.butler.Butler(
-                    butler_uri, writeable=butler_writeable_hack
-                )
+                butler = lsst.daf.butler.Butler(butler_uri)
                 self.registries.append(butler.registry)
         exposurelog_db_url = create_db_url()
 

--- a/src/exposurelog/testutils.py
+++ b/src/exposurelog/testutils.py
@@ -81,9 +81,6 @@ async def create_test_client(
 
         db_config = db_config_from_dsn(postgresql.dsn())
         with modify_environ(
-            # TODO DM-33642: get rid of BUTLER_WRITEABLE_HACK
-            # when safe to do so.
-            BUTLER_WRITEABLE_HACK="true",
             BUTLER_URI_1=str(repo_path),
             BUTLER_URI_2=None if repo_path_2 is None else str(repo_path_2),
             BUTLER_URI_3=None if repo_path_3 is None else str(repo_path_3),

--- a/tests/test_find_exposures.py
+++ b/tests/test_find_exposures.py
@@ -108,8 +108,7 @@ class FindExposuresTestCase(unittest.IsolatedAsyncioTestCase):
         repo_path = pathlib.Path(__file__).parent / "data" / instrument
 
         # Find all exposures in the registry, and save as a list of dicts.
-        # TODO DM-33642: change to writeable=False when safe to do so.
-        butler = lsst.daf.butler.Butler(str(repo_path), writeable=True)
+        butler = lsst.daf.butler.Butler(str(repo_path))
         registry = butler.registry
         exposure_iter = registry.queryDimensionRecords(
             "exposure",
@@ -396,8 +395,7 @@ class FindExposuresTestCase(unittest.IsolatedAsyncioTestCase):
         # thus searches only return exposures from one registry.
         # Use instrument=LATISS to search the second registry
         # in order to test DM-33601.
-        # TODO DM-33642: change to writeable=False when safe to do so.
-        butler = lsst.daf.butler.Butler(str(repo_path_2), writeable=True)
+        butler = lsst.daf.butler.Butler(str(repo_path_2))
         registry = butler.registry
         exposure_iter = registry.queryDimensionRecords(
             "exposure",

--- a/tests/test_shared_state.py
+++ b/tests/test_shared_state.py
@@ -62,9 +62,6 @@ class SharedStateTestCase(unittest.IsolatedAsyncioTestCase):
                         # Hide BUTLER_URI_2 in case it exists in the
                         # user's environment.
                         BUTLER_URI_2=None,
-                        # TODO DM-33642: get rid of BUTLER_WRITEABLE_HACK
-                        # when safe to do so.
-                        BUTLER_WRITEABLE_HACK="true",
                         **missing_required_kwargs,
                         **db_config,
                     ):
@@ -78,9 +75,6 @@ class SharedStateTestCase(unittest.IsolatedAsyncioTestCase):
                     BUTLER_URI_1=str(repo_path),
                     BUTLER_URI_2=None,
                     SITE_ID=bad_site_id,
-                    # TODO DM-33642: get rid of BUTLER_WRITEABLE_HACK
-                    # when safe to do so.
-                    BUTLER_WRITEABLE_HACK="true",
                     **db_config,
                 ):
                     assert not has_shared_state()
@@ -91,9 +85,6 @@ class SharedStateTestCase(unittest.IsolatedAsyncioTestCase):
                 with modify_environ(
                     BUTLER_URI_1="bad/path/to/repo",
                     SITE_ID=TEST_SITE_ID,
-                    # TODO DM-33642: get rid of BUTLER_WRITEABLE_HACK
-                    # when safe to do so.
-                    BUTLER_WRITEABLE_HACK="true",
                     **db_config,
                 ):
                     assert not has_shared_state()
@@ -108,9 +99,6 @@ class SharedStateTestCase(unittest.IsolatedAsyncioTestCase):
                     bad_db_config = db_config.copy()
                     bad_db_config[key] = bad_value
                     with modify_environ(
-                        # TODO DM-33642: get rid of BUTLER_WRITEABLE_HACK
-                        # when safe to do so.
-                        BUTLER_WRITEABLE_HACK="true",
                         **required_kwargs,
                         **bad_db_config,
                     ):
@@ -121,9 +109,6 @@ class SharedStateTestCase(unittest.IsolatedAsyncioTestCase):
                 # Test a valid shared state with one registry.
                 with modify_environ(
                     BUTLER_URI_2=None,
-                    # TODO DM-33642: get rid of BUTLER_WRITEABLE_HACK
-                    # when safe to do so.
-                    BUTLER_WRITEABLE_HACK="true",
                     **required_kwargs,
                     **db_config,
                 ):
@@ -153,9 +138,6 @@ class SharedStateTestCase(unittest.IsolatedAsyncioTestCase):
                 # Create two butler registries
                 with modify_environ(
                     BUTLER_URI_2=str(repo_path_2),
-                    # TODO DM-33642: get rid of BUTLER_WRITEABLE_HACK
-                    # when safe to do so.
-                    BUTLER_WRITEABLE_HACK="true",
                     **required_kwargs,
                     **db_config,
                 ):


### PR DESCRIPTION
Remove a hack that was needed to work around an issue using Butler in GitHub actions with SQLite versions older than 3.34.0.  (See DM-33641.)  GitHub actions now has a newer version of SQLite than this available.