### PR TITLE
DM-43119: Fix Butler threadsafety issue

### DIFF
--- a/src/exposurelog/butler_factory.py
+++ b/src/exposurelog/butler_factory.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import lsst.daf.butler
+
+__all__ = ("ButlerFactory",)
+
+
+class ButlerFactory:
+    """Factory class for creating Butler instances.
+
+    Instances are created quickly enough that a new one can be made for each
+    incoming request.  However, creating an instance involves some non-trivial
+    synchronous work, it is better not to call these functions directly from
+    within an async function.
+
+    Parameters
+    ----------
+    repositories
+        A mapping from integer "registry" label to Butler configuration URI.
+    """
+
+    def __init__(self, repositories: dict[int, str]):
+        self.repositories = tuple(repositories.keys())
+        self.config_urls = tuple(repositories.values())
+        self._factory = lsst.daf.butler.LabeledButlerFactory(
+            {str(k): v for k, v in repositories.items()}
+        )
+
+    def is_valid_repository(self, repository: int) -> bool:
+        """Return `True` if the specified repository was configured for the
+        factory.
+        """
+        return repository in self.repositories
+
+    def get_butler(self, repository: int) -> lsst.daf.butler.Butler:
+        """Return a Butler instance for the specified repository."""
+        return self._factory.create_butler(
+            label=str(repository), access_token=None
+        )
+
+    def get_all_butlers(self) -> Iterator[lsst.daf.butler.Butler]:
+        """Return a Butler instance for each configured repository."""
+        for repository in self.repositories:
+            yield self.get_butler(repository)

--- a/tests/data/print_registry_contents.py
+++ b/tests/data/print_registry_contents.py
@@ -11,7 +11,7 @@ def print_registry_contents(name: str) -> None:
         The instrument name, which must match the registry name, e.g. "LATISS".
     """
     print(f"\nregistry=instrument={name}\n")
-    butler = lsst.daf.butler.Butler(name, writeable=False)
+    butler = lsst.daf.butler.Butler.from_config(name, writeable=False)
     registry = butler.registry
     record_iter = registry.queryDimensionRecords(
         "exposure",

--- a/tests/test_add_message.py
+++ b/tests/test_add_message.py
@@ -79,11 +79,12 @@ class AddMessageTestCase(unittest.IsolatedAsyncioTestCase):
         ):
             shared_state = get_shared_state()
             exposures = []
-            for registry, instrument in zip(
-                shared_state.registries, ("LSSTCam", "LATISS")
+            for repository, instrument in zip(
+                shared_state.butler_factory.repositories, ("LSSTCam", "LATISS")
             ):
+                butler = shared_state.butler_factory.get_butler(repository)
                 exposures += find_all_exposures(
-                    registry=registry, instrument=instrument
+                    registry=butler.registry, instrument=instrument
                 )
 
             # Add a message whose obs_id matches an exposure

--- a/tests/test_find_exposures.py
+++ b/tests/test_find_exposures.py
@@ -418,7 +418,7 @@ class FindExposuresTestCase(unittest.IsolatedAsyncioTestCase):
             messages,
         ):
             shared_state = get_shared_state()
-            assert len(shared_state.registries) == 2
+            assert len(shared_state.butler_factory.repositories) == 2
 
             async def run_find(
                 find_args: dict[str, typing.Any],

--- a/tests/test_find_exposures.py
+++ b/tests/test_find_exposures.py
@@ -108,7 +108,7 @@ class FindExposuresTestCase(unittest.IsolatedAsyncioTestCase):
         repo_path = pathlib.Path(__file__).parent / "data" / instrument
 
         # Find all exposures in the registry, and save as a list of dicts.
-        butler = lsst.daf.butler.Butler(str(repo_path))
+        butler = lsst.daf.butler.Butler.from_config(str(repo_path))
         registry = butler.registry
         exposure_iter = registry.queryDimensionRecords(
             "exposure",
@@ -395,7 +395,7 @@ class FindExposuresTestCase(unittest.IsolatedAsyncioTestCase):
         # thus searches only return exposures from one registry.
         # Use instrument=LATISS to search the second registry
         # in order to test DM-33601.
-        butler = lsst.daf.butler.Butler(str(repo_path_2))
+        butler = lsst.daf.butler.Butler.from_config(str(repo_path_2))
         registry = butler.registry
         exposure_iter = registry.queryDimensionRecords(
             "exposure",

--- a/tests/test_get_configuration.py
+++ b/tests/test_get_configuration.py
@@ -36,7 +36,7 @@ class GetConfigurationTestCase(unittest.IsolatedAsyncioTestCase):
             messages,
         ):
             shared_state = get_shared_state()
-            assert len(shared_state.registries) == 2
+            assert len(shared_state.butler_factory.repositories) == 2
             response = await client.get("/exposurelog/configuration")
             data = assert_good_response(response)
             assert data["site_id"] == shared_state.site_id

--- a/tests/test_shared_state.py
+++ b/tests/test_shared_state.py
@@ -88,8 +88,10 @@ class SharedStateTestCase(unittest.IsolatedAsyncioTestCase):
                     **db_config,
                 ):
                     assert not has_shared_state()
+                    await create_shared_state()
                     with self.assertRaises(FileNotFoundError):
-                        await create_shared_state()
+                        get_shared_state().butler_factory.get_butler(1)
+                    await delete_shared_state()
 
                 # Test bad database configuration env variables.
                 for key, (
@@ -116,7 +118,7 @@ class SharedStateTestCase(unittest.IsolatedAsyncioTestCase):
                     assert has_shared_state()
 
                     shared_state = get_shared_state()
-                    assert len(shared_state.registries) == 1
+                    assert len(shared_state.butler_factory.repositories) == 1
                     assert shared_state.site_id == required_kwargs["SITE_ID"]
 
                     # Cannot create shared state once it is created.
@@ -145,7 +147,7 @@ class SharedStateTestCase(unittest.IsolatedAsyncioTestCase):
                     assert has_shared_state()
 
                     shared_state = get_shared_state()
-                    assert len(shared_state.registries) == 2
+                    assert len(shared_state.butler_factory.repositories) == 2
             finally:
                 await delete_shared_state()
 


### PR DESCRIPTION
Previously, a single global Butler instance for each repository was created at startup and shared between FastAPI routes.  Because the route handlers use thread pools to prevent the synchronous Butler queries from blocking the async thread, this meant that multiple threads would access the same Butler instance concurrently.

Butler instances are not safe to use simultaneously from multiple threads, and this can cause transactions to get stuck open or other strange behavior.  Stuck transactions led to problems running a migration script on the summit Butler databases.

We now construct Butler instances using `LabeledButlerFactory`, which lets you efficiently create a new Butler instance for each incoming HTTP request.  This avoids the threadsafety problems by having only one thread access each Butler instance.