### PR TITLE
DM-43388: Fix compatibility with Butler universe 6

### DIFF
--- a/src/exposurelog/exposure.py
+++ b/src/exposurelog/exposure.py
@@ -33,9 +33,6 @@ class Exposure(pydantic.BaseModel):
         description="String group identifier associated with this exposure "
         "by the acquisition system."
     )
-    group_id: int = pydantic.Field(
-        description="Integer derived from 'group_name'."
-    )
     target_name: str = pydantic.Field(
         description="Object of interest for this observation or survey field name."
     )

--- a/src/exposurelog/routers/find_exposures.py
+++ b/src/exposurelog/routers/find_exposures.py
@@ -252,6 +252,10 @@ def dict_from_exposure(
     timespan = data.pop("timespan")
     data["timespan_begin"] = getattr(timespan.begin, "datetime", None)
     data["timespan_end"] = getattr(timespan.end, "datetime", None)
+    # "group_name" is renamed to just "group" for repositories with Butler
+    # universe version 6 and later.
+    if data.get("group_name") is None:
+        data["group_name"] = data.get("group")
     return data
 
 

--- a/tests/data/README.rst
+++ b/tests/data/README.rst
@@ -56,7 +56,6 @@ exposure:
   day_obs: 20190322
   seq_num: 2
   group_name: '3019032200002'
-  group_id: 3019032200002
   target_name: 'UNKNOWN'
   science_program: '6489D'
   tracking_ra: None
@@ -77,7 +76,6 @@ exposure:
   day_obs: 20190319
   seq_num: 1
   group_name: '3019031900001'
-  group_id: 3019031900001
   target_name: 'UNKNOWN'
   science_program: 'unknown'
   tracking_ra: None
@@ -101,7 +99,6 @@ exposure:
   day_obs: 20220208
   seq_num: 143
   group_name: '2022-02-09T00:55:40.390'
-  group_id: 2242977403900000
   target_name: 'HD  49790'
   science_program: 'CWFS'
   tracking_ra: 102.278392749663
@@ -122,7 +119,6 @@ exposure:
   day_obs: 20220208
   seq_num: 151
   group_name: '2022-02-09T01:18:55.093'
-  group_id: 2242991350930000
   target_name: 'HD  49790'
   science_program: 'unknown'
   tracking_ra: 102.292270913397
@@ -143,7 +139,6 @@ exposure:
   day_obs: 20220208
   seq_num: 145
   group_name: '2022-02-09T00:55:40.390'
-  group_id: 2242977403900000
   target_name: 'HD  49790'
   science_program: 'CWFS'
   tracking_ra: 102.278418936765
@@ -164,7 +159,6 @@ exposure:
   day_obs: 20220208
   seq_num: 150
   group_name: '2022-02-09T01:18:55.093'
-  group_id: 2242991350930000
   target_name: 'HD  49790'
   science_program: 'unknown'
   tracking_ra: 102.292177163303
@@ -185,7 +179,6 @@ exposure:
   day_obs: 20220208
   seq_num: 144
   group_name: '2022-02-09T00:55:40.390'
-  group_id: 2242977403900000
   target_name: 'HD  49790'
   science_program: 'CWFS'
   tracking_ra: 102.278389105931
@@ -206,7 +199,6 @@ exposure:
   day_obs: 20220208
   seq_num: 140
   group_name: '2022-02-09T00:55:40.390'
-  group_id: 2242977403900000
   target_name: 'HD  49790'
   science_program: 'CWFS'
   tracking_ra: 102.278403320713
@@ -227,7 +219,6 @@ exposure:
   day_obs: 20220208
   seq_num: 146
   group_name: '2022-02-09T00:55:40.390'
-  group_id: 2242977403900000
   target_name: 'HD  49790'
   science_program: 'CWFS'
   tracking_ra: 102.278455280663
@@ -248,7 +239,6 @@ exposure:
   day_obs: 20220208
   seq_num: 141
   group_name: '2022-02-09T00:55:40.390'
-  group_id: 2242977403900000
   target_name: 'HD  49790'
   science_program: 'CWFS'
   tracking_ra: 102.278442397096
@@ -269,7 +259,6 @@ exposure:
   day_obs: 20220208
   seq_num: 142
   group_name: '2022-02-09T00:55:40.390'
-  group_id: 2242977403900000
   target_name: 'HD  49790'
   science_program: 'CWFS'
   tracking_ra: 102.27839886926
@@ -290,7 +279,6 @@ exposure:
   day_obs: 20220208
   seq_num: 147
   group_name: '2022-02-09T00:55:40.390'
-  group_id: 2242977403900000
   target_name: 'HD  49790'
   science_program: 'CWFS'
   tracking_ra: 102.278419655072
@@ -311,7 +299,6 @@ exposure:
   day_obs: 20220208
   seq_num: 148
   group_name: '2022-02-09T01:15:40.129'
-  group_id: 2242989401290000
   target_name: 'HD  49790'
   science_program: 'unknown'
   tracking_ra: 102.278466428031
@@ -332,7 +319,6 @@ exposure:
   day_obs: 20220208
   seq_num: 149
   group_name: '2022-02-09T01:18:55.093'
-  group_id: 2242991350930000
   target_name: 'HD  49790'
   science_program: 'unknown'
   tracking_ra: 102.278528804567

--- a/tests/test_find_exposures.py
+++ b/tests/test_find_exposures.py
@@ -338,21 +338,21 @@ class FindExposuresTestCase(unittest.IsolatedAsyncioTestCase):
                 data_dicts=found_exposures, order_by=order_by
             )
 
-            # group_id is not sufficient (there are duplicates)
+            # group_name is not sufficient (there are duplicates)
             # but the service appends "id" if "id" if not specified.
-            response = await run_find(dict(order_by=["group_id"]))
+            response = await run_find(dict(order_by=["group_name"]))
             exposures.sort(
-                key=lambda exposure: (exposure["group_id"], exposure["id"])
+                key=lambda exposure: (exposure["group_name"], exposure["id"])
             )
             assert_good_find_response(
                 response, exposures, predicate=lambda exposure: True
             )
 
-            # Now check group_id with -id to make sure the service
+            # Now check group_name with -id to make sure the service
             # is not appending id after the -id.
-            response = await run_find(dict(order_by=["group_id", "-id"]))
+            response = await run_find(dict(order_by=["group_name", "-id"]))
             exposures.sort(
-                key=lambda exposure: (exposure["group_id"], -exposure["id"])
+                key=lambda exposure: (exposure["group_name"], -exposure["id"])
             )
             assert_good_find_response(
                 response, exposures, predicate=lambda exposure: True


### PR DESCRIPTION
The Butler repositories used by exposurelog will be updated to a new database schema soon.  The new schema removes the the "group_id" property from exposure, and renames "group_name" to "group.

This affects the Exposure objects returned by the /exposures/ endpoint.  It is believed that group_id is unused by downstream consumers of exposurelog, so it has been removed entirely.  group_name is used by LOVE, so we now pull this property from whichever of "group_name" or "group" is available.