### PR TITLE
DM-44704: Fix compatibility with Butler universe 7

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,46 +4,49 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/dev.in
 #
-anyio==3.6.2
+anyio==4.4.0
     # via
     #   -c requirements/main.txt
-    #   httpcore
+    #   httpx
 asn1crypto==1.5.1
     # via scramp
 black==23.3.0
     # via -r requirements/dev.in
-certifi==2022.12.7
+certifi==2024.6.2
     # via
+    #   -c requirements/main.txt
     #   httpcore
     #   httpx
-cfgv==3.3.1
+cfgv==3.4.0
     # via pre-commit
-click==8.1.3
+click==8.1.7
     # via
     #   -c requirements/main.txt
     #   -r requirements/dev.in
     #   black
-coverage[toml]==7.2.3
-    # via
-    #   -r requirements/dev.in
-    #   coverage
-distlib==0.3.6
+coverage[toml]==7.5.3
+    # via -r requirements/dev.in
+distlib==0.3.8
     # via virtualenv
-filelock==3.11.0
+filelock==3.14.0
     # via virtualenv
-flake8==6.0.0
+flake8==6.1.0
     # via -r requirements/dev.in
 h11==0.14.0
     # via
     #   -c requirements/main.txt
     #   httpcore
-httpcore==0.17.0
-    # via httpx
-httpx==0.24.0
-    # via -r requirements/dev.in
-identify==2.5.22
+httpcore==1.0.5
+    # via
+    #   -c requirements/main.txt
+    #   httpx
+httpx==0.27.0
+    # via
+    #   -c requirements/main.txt
+    #   -r requirements/dev.in
+identify==2.5.36
     # via pre-commit
-idna==3.4
+idna==3.7
     # via
     #   -c requirements/main.txt
     #   anyio
@@ -58,57 +61,53 @@ mypy-extensions==1.0.0
     # via
     #   black
     #   mypy
-nodeenv==1.7.0
+nodeenv==1.9.1
     # via pre-commit
-packaging==23.1
+packaging==24.0
     # via
     #   -c requirements/main.txt
     #   black
     #   pytest
-pathspec==0.11.1
+pathspec==0.12.1
     # via black
-pg8000==1.29.4
+pg8000==1.31.2
     # via testing-postgresql
-platformdirs==3.2.0
+platformdirs==4.2.2
     # via
     #   black
     #   virtualenv
-pluggy==1.0.0
+pluggy==1.5.0
     # via pytest
-pre-commit==3.2.2
+pre-commit==3.7.1
     # via -r requirements/dev.in
-pycodestyle==2.10.0
+pycodestyle==2.11.1
     # via flake8
-pyflakes==3.0.1
+pyflakes==3.1.0
     # via flake8
-pytest==7.3.0
+pytest==7.4.4
     # via -r requirements/dev.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via pg8000
 pyyaml==6.0.1
     # via
     #   -c requirements/main.txt
     #   pre-commit
-scramp==1.4.4
+scramp==1.4.5
     # via pg8000
 six==1.16.0
     # via python-dateutil
-sniffio==1.3.0
+sniffio==1.3.1
     # via
     #   -c requirements/main.txt
     #   anyio
-    #   httpcore
     #   httpx
 testing-common-database==2.0.3
     # via testing-postgresql
 testing-postgresql==1.3.0
     # via -r requirements/dev.in
-typing-extensions==4.10.0
+typing-extensions==4.12.1
     # via
     #   -c requirements/main.txt
     #   mypy
-virtualenv==20.21.0
+virtualenv==20.26.2
     # via pre-commit
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -8,7 +8,7 @@
 # Resolve a dependency issue by forcing a version of packaging.
 packaging>=22.0
 alembic~=1.10
-astropy~=5.2
+astropy>=5.2
 asyncpg~=0.27
 fastapi<1
 importlib_metadata~=6.3

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -4,63 +4,98 @@
 #
 #    pip-compile --output-file=requirements/main.txt requirements/main.in
 #
-alembic==1.10.3
+alembic==1.13.1
     # via -r requirements/main.in
-annotated-types==0.6.0
+annotated-types==0.7.0
     # via pydantic
-anyio==3.6.2
-    # via starlette
-astropy==5.2.2
+anyio==4.4.0
+    # via
+    #   httpx
+    #   starlette
+    #   watchfiles
+astropy==6.1.0
     # via
     #   -r requirements/main.in
     #   lsst-daf-butler
     #   lsst-utils
-asyncpg==0.27.0
+astropy-iers-data==0.2024.6.3.0.31.14
+    # via astropy
+async-timeout==4.0.3
+    # via asyncpg
+asyncpg==0.29.0
     # via -r requirements/main.in
-click==8.1.3
+certifi==2024.6.2
+    # via
+    #   httpcore
+    #   httpx
+click==8.1.7
     # via
     #   lsst-daf-butler
+    #   typer
     #   uvicorn
-deprecated==1.2.13
+deprecated==1.2.14
     # via
     #   lsst-daf-butler
     #   lsst-daf-relation
     #   lsst-resources
     #   lsst-utils
-fastapi==0.109.2
+dnspython==2.6.1
+    # via email-validator
+email-validator==2.1.1
+    # via fastapi
+fastapi==0.111.0
     # via -r requirements/main.in
-greenlet==2.0.2
+fastapi-cli==0.0.4
+    # via fastapi
+greenlet==3.0.3
     # via sqlalchemy
 h11==0.14.0
-    # via uvicorn
-hpgeom==0.8.2
-    # via lsst-sphgeom
-idna==3.4
-    # via anyio
-importlib-metadata==6.3.0
-    # via -r requirements/main.in
-importlib-resources==6.1.2
     # via
-    #   lsst-resources
-    #   lsst-utils
-lsst-daf-butler[postgres]==26.2024.900
+    #   httpcore
+    #   uvicorn
+hpgeom==1.3.0
+    # via lsst-sphgeom
+httpcore==1.0.5
+    # via httpx
+httptools==0.6.1
+    # via uvicorn
+httpx==0.27.0
+    # via fastapi
+idna==3.7
+    # via
+    #   anyio
+    #   email-validator
+    #   httpx
+importlib-metadata==6.11.0
     # via -r requirements/main.in
-lsst-daf-relation==26.2024.900
+importlib-resources==6.4.0
+    # via lsst-utils
+jinja2==3.1.4
+    # via fastapi
+lsst-daf-butler[postgres]==27.2024.2300
+    # via -r requirements/main.in
+lsst-daf-relation==27.2024.2300
     # via lsst-daf-butler
-lsst-resources==26.2024.500
+lsst-resources==27.2024.2300
     # via lsst-daf-butler
-lsst-sphgeom==26.2024.900
+lsst-sphgeom==27.2024.2300
     # via lsst-daf-butler
-lsst-utils==26.2024.900
+lsst-utils==27.2024.2200
     # via
     #   lsst-daf-butler
     #   lsst-daf-relation
     #   lsst-resources
-mako==1.2.4
+mako==1.3.5
     # via alembic
-markupsafe==2.1.2
-    # via mako
-numpy==1.24.2
+markdown-it-py==3.0.0
+    # via rich
+markupsafe==2.1.5
+    # via
+    #   jinja2
+    #   mako
+mdurl==0.1.2
+    # via markdown-it-py
+numpy==1.26.4
     # via
     #   astropy
     #   hpgeom
@@ -68,54 +103,82 @@ numpy==1.24.2
     #   lsst-utils
     #   pyarrow
     #   pyerfa
-packaging==23.1
+orjson==3.10.3
+    # via fastapi
+packaging==24.0
     # via
     #   -r requirements/main.in
     #   astropy
-psutil==5.9.4
+psutil==5.9.8
     # via lsst-utils
-psycopg2==2.9.6
+psycopg2==2.9.9
     # via lsst-daf-butler
-pyarrow==15.0.0
+pyarrow==16.1.0
     # via lsst-daf-butler
-pydantic==2.6.3
+pydantic==2.7.3
     # via
     #   fastapi
     #   lsst-daf-butler
     #   lsst-daf-relation
-pydantic-core==2.16.3
+pydantic-core==2.18.4
     # via pydantic
-pyerfa==2.0.0.3
+pyerfa==2.0.1.4
     # via astropy
+pygments==2.18.0
+    # via rich
+python-dotenv==1.0.1
+    # via uvicorn
+python-multipart==0.0.9
+    # via fastapi
 pyyaml==6.0.1
     # via
     #   astropy
     #   lsst-daf-butler
     #   lsst-utils
-sniffio==1.3.0
-    # via anyio
-sqlalchemy==2.0.9
+    #   uvicorn
+rich==13.7.1
+    # via typer
+shellingham==1.5.4
+    # via typer
+sniffio==1.3.1
+    # via
+    #   anyio
+    #   httpx
+sqlalchemy==2.0.30
     # via
     #   -r requirements/main.in
     #   alembic
     #   lsst-daf-butler
     #   lsst-daf-relation
-starlette==0.36.3
+starlette==0.37.2
     # via fastapi
-structlog==23.1.0
+structlog==23.3.0
     # via -r requirements/main.in
-threadpoolctl==3.1.0
+threadpoolctl==3.5.0
     # via lsst-utils
-typing-extensions==4.10.0
+typer==0.12.3
+    # via fastapi-cli
+typing-extensions==4.12.1
     # via
     #   alembic
     #   fastapi
     #   pydantic
     #   pydantic-core
     #   sqlalchemy
-uvicorn==0.21.1
-    # via -r requirements/main.in
-wrapt==1.15.0
+    #   typer
+ujson==5.10.0
+    # via fastapi
+uvicorn[standard]==0.30.1
+    # via
+    #   -r requirements/main.in
+    #   fastapi
+uvloop==0.19.0
+    # via uvicorn
+watchfiles==0.22.0
+    # via uvicorn
+websockets==12.0
+    # via uvicorn
+wrapt==1.16.0
     # via deprecated
-zipp==3.15.0
+zipp==3.19.2
     # via importlib-metadata


### PR DESCRIPTION
This PR was created to fix an incompatibility with the latest update of the Butler to Universe 7. When querying the `/exposures` endpoint and setting `exposure.day_obs = day_obs` the butler query failed returning the following response:

```
{
  "detail": "Error in butler query instrument='LATISS', bind={'min_day_obs': 20240605, 'max_day_obs': 20240607}, where='exposure.day_obs >= min_day_obs and exposure.day_obs < max_day_obs', limit=1500, offset=None, order_by=['-obs_id', 'id']: RuntimeError(\"Invalid reference to 'exposure.day_obs' in expression; please use 'day_obs' or 'day_obs.id' instead.\")"
}
``` 

Updating `lsst-daf-butler` dependency seems to fix the issue.

Also other dependencies were updated in the process.