### PR TITLE
DM-44769: Add lsst-daf-butler s3 extra dependency

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/dev.in
 #
-anyio==4.4.0
+anyio==4.6.0
     # via
     #   -c requirements/main.txt
     #   httpx
@@ -12,9 +12,8 @@ asn1crypto==1.5.1
     # via scramp
 black==23.3.0
     # via -r requirements/dev.in
-certifi==2024.6.2
+certifi==2024.8.30
     # via
-    #   -c requirements/main.txt
     #   httpcore
     #   httpx
 cfgv==3.4.0
@@ -24,11 +23,11 @@ click==8.1.7
     #   -c requirements/main.txt
     #   -r requirements/dev.in
     #   black
-coverage[toml]==7.5.3
+coverage[toml]==7.6.1
     # via -r requirements/dev.in
 distlib==0.3.8
     # via virtualenv
-filelock==3.14.0
+filelock==3.16.1
     # via virtualenv
 flake8==6.1.0
     # via -r requirements/dev.in
@@ -37,16 +36,12 @@ h11==0.14.0
     #   -c requirements/main.txt
     #   httpcore
 httpcore==1.0.5
-    # via
-    #   -c requirements/main.txt
-    #   httpx
-httpx==0.27.0
-    # via
-    #   -c requirements/main.txt
-    #   -r requirements/dev.in
-identify==2.5.36
+    # via httpx
+httpx==0.27.2
+    # via -r requirements/dev.in
+identify==2.6.1
     # via pre-commit
-idna==3.7
+idna==3.10
     # via
     #   -c requirements/main.txt
     #   anyio
@@ -63,7 +58,7 @@ mypy-extensions==1.0.0
     #   mypy
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.0
+packaging==24.1
     # via
     #   -c requirements/main.txt
     #   black
@@ -72,13 +67,13 @@ pathspec==0.12.1
     # via black
 pg8000==1.31.2
     # via testing-postgresql
-platformdirs==4.2.2
+platformdirs==4.3.6
     # via
     #   black
     #   virtualenv
 pluggy==1.5.0
     # via pytest
-pre-commit==3.7.1
+pre-commit==3.8.0
     # via -r requirements/dev.in
 pycodestyle==2.11.1
     # via flake8
@@ -87,15 +82,19 @@ pyflakes==3.1.0
 pytest==7.4.4
     # via -r requirements/dev.in
 python-dateutil==2.9.0.post0
-    # via pg8000
-pyyaml==6.0.1
+    # via
+    #   -c requirements/main.txt
+    #   pg8000
+pyyaml==6.0.2
     # via
     #   -c requirements/main.txt
     #   pre-commit
 scramp==1.4.5
     # via pg8000
 six==1.16.0
-    # via python-dateutil
+    # via
+    #   -c requirements/main.txt
+    #   python-dateutil
 sniffio==1.3.1
     # via
     #   -c requirements/main.txt
@@ -105,9 +104,9 @@ testing-common-database==2.0.3
     # via testing-postgresql
 testing-postgresql==1.3.0
     # via -r requirements/dev.in
-typing-extensions==4.12.1
+typing-extensions==4.12.2
     # via
     #   -c requirements/main.txt
     #   mypy
-virtualenv==20.26.2
+virtualenv==20.26.5
     # via pre-commit

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -15,5 +15,4 @@ importlib_metadata~=6.3
 sqlalchemy~=2.0
 structlog~=23.1
 uvicorn~=0.21
-lsst-daf-butler[postgres]
-
+lsst-daf-butler[s3, postgres]

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -4,34 +4,34 @@
 #
 #    pip-compile --output-file=requirements/main.txt requirements/main.in
 #
-alembic==1.13.1
+alembic==1.13.3
     # via -r requirements/main.in
 annotated-types==0.7.0
     # via pydantic
-anyio==4.4.0
-    # via
-    #   httpx
-    #   starlette
-    #   watchfiles
-astropy==6.1.0
+anyio==4.6.0
+    # via starlette
+astropy==6.1.3
     # via
     #   -r requirements/main.in
     #   lsst-daf-butler
     #   lsst-utils
-astropy-iers-data==0.2024.6.3.0.31.14
+astropy-iers-data==0.2024.9.23.0.31.43
     # via astropy
 async-timeout==4.0.3
     # via asyncpg
 asyncpg==0.29.0
     # via -r requirements/main.in
-certifi==2024.6.2
+backoff==2.2.1
+    # via lsst-resources
+boto3==1.35.25
+    # via lsst-resources
+botocore==1.35.25
     # via
-    #   httpcore
-    #   httpx
+    #   boto3
+    #   s3transfer
 click==8.1.7
     # via
     #   lsst-daf-butler
-    #   typer
     #   uvicorn
 deprecated==1.2.14
     # via
@@ -39,63 +39,40 @@ deprecated==1.2.14
     #   lsst-daf-relation
     #   lsst-resources
     #   lsst-utils
-dnspython==2.6.1
-    # via email-validator
-email-validator==2.1.1
-    # via fastapi
-fastapi==0.111.0
+fastapi==0.115.0
     # via -r requirements/main.in
-fastapi-cli==0.0.4
-    # via fastapi
-greenlet==3.0.3
+greenlet==3.1.1
     # via sqlalchemy
 h11==0.14.0
-    # via
-    #   httpcore
-    #   uvicorn
-hpgeom==1.3.0
-    # via lsst-sphgeom
-httpcore==1.0.5
-    # via httpx
-httptools==0.6.1
     # via uvicorn
-httpx==0.27.0
-    # via fastapi
-idna==3.7
-    # via
-    #   anyio
-    #   email-validator
-    #   httpx
+hpgeom==1.3.2
+    # via lsst-sphgeom
+idna==3.10
+    # via anyio
 importlib-metadata==6.11.0
     # via -r requirements/main.in
-importlib-resources==6.4.0
-    # via lsst-utils
-jinja2==3.1.4
-    # via fastapi
-lsst-daf-butler[postgres]==27.2024.2300
+jmespath==1.0.1
+    # via
+    #   boto3
+    #   botocore
+lsst-daf-butler[postgres,s3]==27.2024.3800
     # via -r requirements/main.in
-lsst-daf-relation==27.2024.2300
+lsst-daf-relation==27.2024.3800
     # via lsst-daf-butler
-lsst-resources==27.2024.2300
+lsst-resources[s3]==27.2024.3600
     # via lsst-daf-butler
-lsst-sphgeom==27.2024.2300
+lsst-sphgeom==27.2024.3700
     # via lsst-daf-butler
-lsst-utils==27.2024.2200
+lsst-utils==27.2024.3800
     # via
     #   lsst-daf-butler
     #   lsst-daf-relation
     #   lsst-resources
 mako==1.3.5
     # via alembic
-markdown-it-py==3.0.0
-    # via rich
 markupsafe==2.1.5
-    # via
-    #   jinja2
-    #   mako
-mdurl==0.1.2
-    # via markdown-it-py
-numpy==1.26.4
+    # via mako
+numpy==2.1.1
     # via
     #   astropy
     #   hpgeom
@@ -103,82 +80,62 @@ numpy==1.26.4
     #   lsst-utils
     #   pyarrow
     #   pyerfa
-orjson==3.10.3
-    # via fastapi
-packaging==24.0
+packaging==24.1
     # via
     #   -r requirements/main.in
     #   astropy
-psutil==5.9.8
+psutil==6.0.0
     # via lsst-utils
 psycopg2==2.9.9
     # via lsst-daf-butler
-pyarrow==16.1.0
+pyarrow==17.0.0
     # via lsst-daf-butler
-pydantic==2.7.3
+pydantic==2.9.2
     # via
     #   fastapi
     #   lsst-daf-butler
     #   lsst-daf-relation
-pydantic-core==2.18.4
+pydantic-core==2.23.4
     # via pydantic
 pyerfa==2.0.1.4
     # via astropy
-pygments==2.18.0
-    # via rich
-python-dotenv==1.0.1
-    # via uvicorn
-python-multipart==0.0.9
-    # via fastapi
-pyyaml==6.0.1
+python-dateutil==2.9.0.post0
+    # via botocore
+pyyaml==6.0.2
     # via
     #   astropy
     #   lsst-daf-butler
     #   lsst-utils
-    #   uvicorn
-rich==13.7.1
-    # via typer
-shellingham==1.5.4
-    # via typer
+s3transfer==0.10.2
+    # via boto3
+six==1.16.0
+    # via python-dateutil
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
-sqlalchemy==2.0.30
+    # via anyio
+sqlalchemy==2.0.35
     # via
     #   -r requirements/main.in
     #   alembic
     #   lsst-daf-butler
     #   lsst-daf-relation
-starlette==0.37.2
+starlette==0.38.6
     # via fastapi
 structlog==23.3.0
     # via -r requirements/main.in
 threadpoolctl==3.5.0
     # via lsst-utils
-typer==0.12.3
-    # via fastapi-cli
-typing-extensions==4.12.1
+typing-extensions==4.12.2
     # via
     #   alembic
     #   fastapi
     #   pydantic
     #   pydantic-core
     #   sqlalchemy
-    #   typer
-ujson==5.10.0
-    # via fastapi
-uvicorn[standard]==0.30.1
-    # via
-    #   -r requirements/main.in
-    #   fastapi
-uvloop==0.19.0
-    # via uvicorn
-watchfiles==0.22.0
-    # via uvicorn
-websockets==12.0
-    # via uvicorn
+urllib3==2.2.3
+    # via botocore
+uvicorn==0.30.6
+    # via -r requirements/main.in
 wrapt==1.16.0
     # via deprecated
-zipp==3.19.2
+zipp==3.20.2
     # via importlib-metadata


### PR DESCRIPTION
This PR was created to allow butler queries from the exposurelog service on deployments that use S3, such as the usdf-dev.